### PR TITLE
Fix/routing identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Fixed
+
+- Type-based routing now matches event subclasses and preserves the original
+  routing identity through `EnrichedEvent` transformers. Other routing
+  conditions still evaluate the transformed event.
+
 ## 2.0.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -474,6 +474,11 @@ FlexTrack.addTransformer((event) => EnrichedEvent(event, {
 
 `EnrichedEvent` is a `BaseEvent` wrapper. It forwards all metadata from the original event (`category`, `containsPII`, `requiresConsent`, etc.) and overrides `properties` to merge the original properties with the extra ones. Extra properties win on key collision.
 
+Type-based routes remain anchored to the original event through any number of
+`EnrichedEvent` wrappers. A `route<PurchaseEvent>()` rule therefore continues
+to match enriched purchases and subclasses of `PurchaseEvent`, while
+property-based routes can still match properties added by transformers.
+
 ```dart
 // Extra properties override originals on the same key.
 EnrichedEvent(originalEvent, {'source': 'transformer'})

--- a/lib/src/models/routing/routing_rule.dart
+++ b/lib/src/models/routing/routing_rule.dart
@@ -1,12 +1,16 @@
 import 'package:flex_track/src/models/event/base_event.dart';
+import 'package:flex_track/src/models/event/enriched_event.dart';
 
 import 'event_category.dart';
 import 'tracker_group.dart';
+
+typedef EventTypeMatcher = bool Function(BaseEvent event);
 
 /// Represents a routing rule that determines where events should be sent
 class RoutingRule {
   final String? id;
   final Type? eventType;
+  final EventTypeMatcher? eventTypeMatcher;
   final String? eventNamePattern;
   final RegExp? eventNameRegex;
   final EventCategory? category;
@@ -28,6 +32,7 @@ class RoutingRule {
   const RoutingRule({
     this.id,
     this.eventType,
+    this.eventTypeMatcher,
     this.eventNamePattern,
     this.eventNameRegex,
     this.category,
@@ -55,7 +60,7 @@ class RoutingRule {
     if (productionOnly && isDebugMode) return false;
 
     // Check event type
-    if (eventType != null && event.runtimeType != eventType) {
+    if (!matchesEventType(event)) {
       return false;
     }
 
@@ -105,6 +110,23 @@ class RoutingRule {
     return true;
   }
 
+  /// Whether [event] satisfies this rule's type condition.
+  ///
+  /// Routing builders provide a subtype-aware matcher for `route<T>()`. The
+  /// event is unwrapped only for this type check so transformed properties and
+  /// metadata continue to participate in the remaining rule conditions.
+  bool matchesEventType(BaseEvent event) {
+    if (eventType == null) return true;
+
+    BaseEvent routingEvent = event;
+    while (routingEvent is EnrichedEvent) {
+      routingEvent = routingEvent.original;
+    }
+
+    return eventTypeMatcher?.call(routingEvent) ??
+        routingEvent.runtimeType == eventType;
+  }
+
   /// Returns true if this rule should be applied based on consent
   bool shouldApply(
     BaseEvent event, {
@@ -139,6 +161,7 @@ class RoutingRule {
   RoutingRule copyWith({
     String? id,
     Type? eventType,
+    EventTypeMatcher? eventTypeMatcher,
     String? eventNamePattern,
     RegExp? eventNameRegex,
     EventCategory? category,
@@ -160,6 +183,7 @@ class RoutingRule {
     return RoutingRule(
       id: id ?? this.id,
       eventType: eventType ?? this.eventType,
+      eventTypeMatcher: eventTypeMatcher ?? this.eventTypeMatcher,
       eventNamePattern: eventNamePattern ?? this.eventNamePattern,
       eventNameRegex: eventNameRegex ?? this.eventNameRegex,
       category: category ?? this.category,

--- a/lib/src/routing/route_config_builder.dart
+++ b/lib/src/routing/route_config_builder.dart
@@ -98,5 +98,6 @@ class RouteConfigBuilder<T extends BaseEvent> {
   // ========== GETTERS FOR RULE BUILDER ==========
 
   Type? get eventType => _eventType;
+  bool matchesEventType(BaseEvent event) => event is T;
   RoutingBuilder get parent => _parent;
 }

--- a/lib/src/routing/routing_engine.dart
+++ b/lib/src/routing/routing_engine.dart
@@ -181,7 +181,7 @@ class RoutingEngine {
   String _getRuleNonMatchReason(RoutingRule rule, BaseEvent event) {
     final reasons = <String>[];
 
-    if (rule.eventType != null && event.runtimeType != rule.eventType) {
+    if (!rule.matchesEventType(event)) {
       reasons.add(
           'Event type mismatch: expected ${rule.eventType}, got ${event.runtimeType}');
     }

--- a/lib/src/routing/routing_rule_builder.dart
+++ b/lib/src/routing/routing_rule_builder.dart
@@ -163,6 +163,8 @@ class RoutingRuleBuilder {
     final rule = RoutingRule(
       id: _id,
       eventType: _config.eventType,
+      eventTypeMatcher:
+          _config.eventType == null ? null : _config.matchesEventType,
       eventNamePattern: _config.eventNamePattern,
       eventNameRegex: _config.eventNameRegex,
       category: _config.category,

--- a/test/routing/routing_identity_test.dart
+++ b/test/routing/routing_identity_test.dart
@@ -1,0 +1,98 @@
+import 'package:flex_track/flex_track.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class PurchaseEvent extends BaseEvent {
+  @override
+  String get name => 'purchase';
+
+  @override
+  Map<String, Object>? get properties => null;
+}
+
+class SubscriptionPurchaseEvent extends PurchaseEvent {}
+
+void main() {
+  group('routing identity', () {
+    late RoutingEngine engine;
+
+    setUp(() {
+      final configuration = (RoutingBuilder()
+            ..route<PurchaseEvent>().to(['billing']).withPriority(10).and()
+            ..routeDefault().to(['other']).and())
+          .build();
+
+      engine = RoutingEngine(configuration);
+    });
+
+    test('a type route matches subclasses', () {
+      final result = engine.routeEvent(
+        SubscriptionPurchaseEvent(),
+        availableTrackers: {'billing', 'other'},
+      );
+
+      expect(result.targetTrackers, ['billing']);
+    });
+
+    test('an enriched event preserves its original type route', () {
+      final result = engine.routeEvent(
+        EnrichedEvent(PurchaseEvent(), {'app_version': '2.1.0'}),
+        availableTrackers: {'billing', 'other'},
+      );
+
+      expect(result.targetTrackers, ['billing']);
+    });
+
+    test('nested enrichment preserves the deepest original type route', () {
+      final result = engine.routeEvent(
+        EnrichedEvent(
+          EnrichedEvent(SubscriptionPurchaseEvent(), {'session': 'one'}),
+          {'app_version': '2.1.0'},
+        ),
+        availableTrackers: {'billing', 'other'},
+      );
+
+      expect(result.targetTrackers, ['billing']);
+    });
+
+    test('transformed properties remain visible to property routes', () {
+      final propertyConfiguration = (RoutingBuilder()
+            ..routeWithProperty('app_version')
+                .to(['versioned'])
+                .withPriority(10)
+                .and()
+            ..routeDefault().to(['other']).and())
+          .build();
+      final propertyEngine = RoutingEngine(propertyConfiguration);
+
+      final result = propertyEngine.routeEvent(
+        EnrichedEvent(PurchaseEvent(), {'app_version': '2.1.0'}),
+        availableTrackers: {'versioned', 'other'},
+      );
+
+      expect(result.targetTrackers, ['versioned']);
+    });
+
+    test('debug output uses the same routing identity semantics', () {
+      final event = EnrichedEvent(SubscriptionPurchaseEvent(), const {});
+
+      final debug = engine.debugEvent(
+        event,
+        availableTrackers: {'billing', 'other'},
+      );
+
+      expect(debug.routingResult.targetTrackers, ['billing']);
+      expect(
+        debug.matchingRules.where(
+          (rule) => rule.eventType == PurchaseEvent,
+        ),
+        hasLength(1),
+      );
+      expect(
+        debug.nonMatchingRules.where(
+          (entry) => entry.rule.eventType == PurchaseEvent,
+        ),
+        isEmpty,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Implemented subtype-aware and transformer-transparent routing on branch fix/routing-identity.
Type routes now match subclasses and preserve the original routing identity through nested EnrichedEvent wrappers. Transformed properties remain available to property-based rules, and routing debug output uses the same matching behavior.
Validation: 817 tests passed and flutter analyze completed successfully.
Ready for review and merge.