### PR TITLE
fix(sampling): make routing decisions deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Type-based routing now matches event subclasses and preserves the original
   routing identity through `EnrichedEvent` transformers. Other routing
   conditions still evaluate the transformed event.
+- Replaced clock-modulo routing sampling with deterministic FNV-1a sampling
+  keyed by user id, session id, or event name. Essential events bypass
+  sampling, and published UTF-8 vectors keep future SDK implementations in
+  parity.
 
 ## 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -928,7 +928,17 @@ GDPRDefaults.applyStrict(routing, compliantTrackers: ['internal']);
 
 ## Sampling and performance
 
-Sampling is applied per-rule. Each matching event independently has a random chance of being forwarded at the specified rate.
+Sampling is applied per rule and is deterministic by default. FlexTrack hashes
+the first non-empty value from `event.userId`, `event.sessionId`, and
+`event.name` with FNV-1a over UTF-8 bytes. The resulting stable bucket is
+compared with the rule's rate, so the same identity receives the same decision
+across launches and SDK implementations. Essential events always bypass
+sampling.
+
+When no user or session identity is available, all events with the same name
+share a decision. Supply a stable user or session id when you need a
+representative user-level sample. The cross-platform vectors are published in
+`test/fixtures/sampling_vectors.json`.
 
 | Method | Rate |
 |--------|------|

--- a/lib/src/models/routing/routing_config.dart
+++ b/lib/src/models/routing/routing_config.dart
@@ -4,6 +4,7 @@ import 'package:flex_track/src/models/event/base_event.dart';
 import 'routing_rule.dart';
 import 'tracker_group.dart';
 import 'event_category.dart';
+import '../../utils/sampling_utils.dart';
 
 /// Complete routing configuration that contains all rules and settings
 class RoutingConfiguration {
@@ -14,6 +15,7 @@ class RoutingConfiguration {
   final bool enableSampling;
   final bool enableConsentChecking;
   final bool isDebugMode;
+  final EventSampler sampler;
 
   const RoutingConfiguration({
     required this.rules,
@@ -23,6 +25,7 @@ class RoutingConfiguration {
     this.enableSampling = true,
     this.enableConsentChecking = true,
     this.isDebugMode = false,
+    this.sampler = const DeterministicEventSampler(),
   });
 
   /// Creates an empty routing configuration
@@ -126,7 +129,7 @@ class RoutingConfiguration {
       }
 
       // Check sampling
-      if (enableSampling && !rule.shouldSample()) {
+      if (enableSampling && !rule.shouldSample(event, sampler: sampler)) {
         continue;
       }
 
@@ -173,6 +176,7 @@ class RoutingConfiguration {
     bool? enableSampling,
     bool? enableConsentChecking,
     bool? isDebugMode,
+    EventSampler? sampler,
   }) {
     return RoutingConfiguration(
       rules: rules ?? this.rules,
@@ -183,6 +187,7 @@ class RoutingConfiguration {
       enableConsentChecking:
           enableConsentChecking ?? this.enableConsentChecking,
       isDebugMode: isDebugMode ?? this.isDebugMode,
+      sampler: sampler ?? this.sampler,
     );
   }
 
@@ -251,6 +256,7 @@ class RoutingConfiguration {
       'enableSampling': enableSampling,
       'enableConsentChecking': enableConsentChecking,
       'isDebugMode': isDebugMode,
+      'sampler': sampler.runtimeType.toString(),
       'rulesCount': rules.length,
       'customGroupsCount': customGroups.length,
       'customCategoriesCount': customCategories.length,

--- a/lib/src/models/routing/routing_rule.dart
+++ b/lib/src/models/routing/routing_rule.dart
@@ -1,5 +1,6 @@
 import 'package:flex_track/src/models/event/base_event.dart';
 import 'package:flex_track/src/models/event/enriched_event.dart';
+import 'package:flex_track/src/utils/sampling_utils.dart';
 
 import 'event_category.dart';
 import 'tracker_group.dart';
@@ -149,12 +150,11 @@ class RoutingRule {
   }
 
   /// Returns true if this rule should be sampled for the given event
-  bool shouldSample() {
-    if (sampleRate >= 1.0) return true;
-    if (sampleRate <= 0.0) return false;
-
-    // Use a simple random sampling
-    return (DateTime.now().millisecondsSinceEpoch % 1000) / 1000.0 < sampleRate;
+  bool shouldSample(
+    BaseEvent event, {
+    EventSampler sampler = const DeterministicEventSampler(),
+  }) {
+    return sampler.shouldSample(event, sampleRate);
   }
 
   /// Creates a copy of this rule with updated properties

--- a/lib/src/routing/routing_engine.dart
+++ b/lib/src/routing/routing_engine.dart
@@ -64,7 +64,8 @@ class RoutingEngine {
         }
 
         // Check sampling
-        if (_configuration.enableSampling && !rule.shouldSample()) {
+        if (_configuration.enableSampling &&
+            !rule.shouldSample(event, sampler: _configuration.sampler)) {
           skippedRules.add(SkippedRule(
             rule: rule,
             reason:

--- a/lib/src/utils/sampling_utils.dart
+++ b/lib/src/utils/sampling_utils.dart
@@ -1,4 +1,28 @@
+import 'dart:convert';
 import 'dart:math' as math;
+
+import '../models/event/base_event.dart';
+
+/// Decides whether an event is retained for a routing rule's sample rate.
+abstract interface class EventSampler {
+  bool shouldSample(BaseEvent event, double sampleRate);
+}
+
+/// Cross-platform deterministic sampler using FNV-1a over UTF-8 bytes.
+class DeterministicEventSampler implements EventSampler {
+  const DeterministicEventSampler();
+
+  @override
+  bool shouldSample(BaseEvent event, double sampleRate) {
+    if (event.isEssential) return true;
+    if (sampleRate >= 1.0) return true;
+    if (sampleRate <= 0.0) return false;
+    return SamplingUtils.shouldSampleDeterministic(
+      SamplingUtils.samplingKey(event),
+      sampleRate,
+    );
+  }
+}
 
 /// Utility class for event sampling operations
 class SamplingUtils {
@@ -19,11 +43,36 @@ class SamplingUtils {
     if (sampleRate >= 1.0) return true;
     if (sampleRate <= 0.0) return false;
 
-    // Use hash of input for deterministic sampling
-    final hash = input.hashCode.abs();
-    final normalizedHash = (hash % 10000) / 10000.0;
+    final normalizedHash = stableHash(input) / 0x100000000;
 
     return normalizedHash < sampleRate;
+  }
+
+  /// Stable FNV-1a 32-bit hash over the UTF-8 bytes of [input].
+  ///
+  /// Unlike Dart's [String.hashCode], this algorithm is explicitly defined
+  /// and can produce identical sampling decisions on every SDK platform.
+  static int stableHash(String input) {
+    var hash = 0x811c9dc5;
+    for (final byte in utf8.encode(input)) {
+      hash ^= byte;
+      hash = (hash * 0x01000193) & 0xffffffff;
+    }
+    return hash;
+  }
+
+  /// Stable identity used by the default routing sampler.
+  ///
+  /// Empty identity values are ignored. Event name is the deterministic
+  /// fallback until an application supplies a user or session identity.
+  static String samplingKey(BaseEvent event) {
+    final userId = event.userId;
+    if (userId != null && userId.isNotEmpty) return userId;
+
+    final sessionId = event.sessionId;
+    if (sessionId != null && sessionId.isNotEmpty) return sessionId;
+
+    return event.name;
   }
 
   /// Check if an event should be sampled based on user ID
@@ -112,7 +161,7 @@ class SamplingUtils {
   static int getSamplingBucket(String identifier, int bucketCount) {
     if (bucketCount <= 0) return 0;
 
-    final hash = identifier.hashCode.abs();
+    final hash = stableHash(identifier);
     return hash % bucketCount;
   }
 

--- a/test/fixtures/sampling_vectors.json
+++ b/test/fixtures/sampling_vectors.json
@@ -1,0 +1,26 @@
+{
+  "algorithm": "fnv1a-32-utf8",
+  "bucketDivisor": 4294967296,
+  "vectors": [
+    {"input": "", "hash": 2166136261, "at25": false, "at50": false},
+    {"input": "a", "hash": 3826002220, "at25": false, "at50": false},
+    {"input": "hello", "hash": 1335831723, "at25": false, "at50": true},
+    {"input": "purchase", "hash": 2513801058, "at25": false, "at50": false},
+    {"input": "user-123", "hash": 2358496403, "at25": false, "at50": false},
+    {"input": "session-α", "hash": 2520526275, "at25": false, "at50": false},
+    {"input": "你好", "hash": 2257816995, "at25": false, "at50": false},
+    {"input": "🙂", "hash": 1470331467, "at25": false, "at50": true},
+    {"input": "résumé", "hash": 3068721788, "at25": false, "at50": false},
+    {"input": "مرحبا", "hash": 2831450846, "at25": false, "at50": false},
+    {"input": "नमस्ते", "hash": 538106393, "at25": true, "at50": true},
+    {"input": "Straße", "hash": 499330616, "at25": true, "at50": true},
+    {"input": "null\u0000byte", "hash": 1921921222, "at25": false, "at50": true},
+    {"input": "line\nbreak", "hash": 527786666, "at25": true, "at50": true},
+    {"input": "emoji-🚀", "hash": 2040893807, "at25": false, "at50": true},
+    {"input": "UPPER_lower-123", "hash": 1815750080, "at25": false, "at50": true},
+    {"input": "café", "hash": 2821410889, "at25": false, "at50": false},
+    {"input": "mañana", "hash": 798077619, "at25": true, "at50": true},
+    {"input": "東京", "hash": 1759422319, "at25": false, "at50": true},
+    {"input": "한국어", "hash": 18907935, "at25": true, "at50": true}
+  ]
+}

--- a/test/routing/sampling_correctness_test.dart
+++ b/test/routing/sampling_correctness_test.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flex_track/flex_track.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class SamplingEvent extends BaseEvent {
+  SamplingEvent({this.eventUserId, this.eventSessionId});
+
+  final String? eventUserId;
+  final String? eventSessionId;
+
+  @override
+  String get name => 'purchase';
+
+  @override
+  Map<String, Object>? get properties => null;
+
+  @override
+  String? get userId => eventUserId;
+
+  @override
+  String? get sessionId => eventSessionId;
+}
+
+class RecordingSampler implements EventSampler {
+  BaseEvent? event;
+  double? rate;
+
+  @override
+  bool shouldSample(BaseEvent event, double sampleRate) {
+    this.event = event;
+    rate = sampleRate;
+    return false;
+  }
+}
+
+void main() {
+  group('cross-platform deterministic sampling', () {
+    final fixture = jsonDecode(
+      File('test/fixtures/sampling_vectors.json').readAsStringSync(),
+    ) as Map<String, dynamic>;
+    final vectors = fixture['vectors'] as List<dynamic>;
+
+    test('uses the documented FNV-1a UTF-8 vectors', () {
+      for (final value in vectors.cast<Map<String, dynamic>>()) {
+        final input = value['input'] as String;
+
+        expect(
+          SamplingUtils.stableHash(input),
+          value['hash'],
+          reason: 'hash mismatch for ${jsonEncode(input)}',
+        );
+        expect(
+          SamplingUtils.shouldSampleDeterministic(input, 0.25),
+          value['at25'],
+          reason: '25% decision mismatch for ${jsonEncode(input)}',
+        );
+        expect(
+          SamplingUtils.shouldSampleDeterministic(input, 0.50),
+          value['at50'],
+          reason: '50% decision mismatch for ${jsonEncode(input)}',
+        );
+      }
+    });
+
+    test('uses user, session, then event name as the stable key', () {
+      expect(SamplingUtils.samplingKey(SamplingEvent(eventUserId: 'user-1')),
+          'user-1');
+      expect(
+        SamplingUtils.samplingKey(
+          SamplingEvent(eventUserId: '', eventSessionId: 'session-1'),
+        ),
+        'session-1',
+      );
+      expect(SamplingUtils.samplingKey(SamplingEvent()), 'purchase');
+    });
+
+    test('makes repeated routing decisions independent of wall-clock time', () {
+      final rule = RoutingRule(
+        targetGroup: TrackerGroup.all,
+        sampleRate: 0.5,
+      );
+      final event = SamplingEvent(eventUserId: 'stable-user');
+
+      final decisions = List.generate(1000, (_) => rule.shouldSample(event));
+
+      expect(decisions.toSet(), hasLength(1));
+    });
+
+    test('always keeps essential events and boundary rate one', () {
+      final essential = _EssentialSamplingEvent();
+
+      expect(
+        const RoutingRule(
+          targetGroup: TrackerGroup.all,
+          sampleRate: 0,
+        ).shouldSample(essential),
+        isTrue,
+      );
+      expect(
+        const RoutingRule(
+          targetGroup: TrackerGroup.all,
+          sampleRate: 1,
+        ).shouldSample(SamplingEvent()),
+        isTrue,
+      );
+    });
+
+    test('allows the sampler to be injected through routing configuration', () {
+      final sampler = RecordingSampler();
+      final event = SamplingEvent(eventUserId: 'user-1');
+      final configuration = RoutingConfiguration(
+        rules: const [
+          RoutingRule(targetGroup: TrackerGroup.all, sampleRate: 0.5),
+        ],
+        sampler: sampler,
+      );
+
+      final result = RoutingEngine(configuration).routeEvent(
+        event,
+        availableTrackers: {'console'},
+      );
+
+      expect(result.targetTrackers, isEmpty);
+      expect(sampler.event, same(event));
+      expect(sampler.rate, 0.5);
+    });
+  });
+}
+
+class _EssentialSamplingEvent extends SamplingEvent {
+  @override
+  bool get isEssential => true;
+}


### PR DESCRIPTION
Replace clock-modulo routing decisions with injectable FNV-1a sampling keyed by user, session, or event name. Add UTF-8 conformance vectors, essential-event bypass, regression coverage, and public documentation.

Closes #18