### PR TITLE
fix: stabilize event metadata and consent defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   keyed by user id, session id, or event name. Essential events bypass
   sampling, and published UTF-8 vectors keep future SDK implementations in
   parity.
+- Event instances now capture an immutable UUID v4 identifier and UTC
+  occurrence timestamp. Enrichment preserves both values.
+- New clients now start with general and PII consent denied, matching the
+  documented privacy-safe default. Disabling consent checking on a routing
+  configuration now bypasses those checks as configured.
+- `flexTrackVersion` now matches the package version declared in `pubspec.yaml`.
 
 ## 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ This package does not bundle Firebase, Mixpanel, Amplitude, or any other analyti
 
 Extend `BaseEvent` and implement the `name` and `properties` getters. Everything else is optional.
 
+Every event receives an immutable UUID v4 `eventId` and UTC `timestamp` when
+it is constructed. Those values remain unchanged through enrichment and
+dispatch. For replay or restored offline events, pass the original metadata to
+`super(eventId: storedId, timestamp: storedTimestamp)` from your event
+constructor.
+
 ```dart
 class PurchaseEvent extends BaseEvent {
   final double amount;

--- a/example/lib/events/app_events.dart
+++ b/example/lib/events/app_events.dart
@@ -39,14 +39,12 @@ class AppStartEvent extends BaseEvent {
 class PageViewEvent extends BaseEvent {
   final String pageName;
   final Map<String, String>? parameters;
-  @override
-  final DateTime timestamp;
 
   PageViewEvent({
     required this.pageName,
     this.parameters,
-    DateTime? timestamp,
-  }) : timestamp = timestamp ?? DateTime.now();
+    super.timestamp,
+  });
 
   @override
   String get name => 'page_view';

--- a/lib/flex_track.dart
+++ b/lib/flex_track.dart
@@ -143,7 +143,7 @@ export 'src/core/flex_track.dart' show FlexTrack;
 // ============= VERSION INFO =============
 
 /// FlexTrack package version
-const String flexTrackVersion = '1.0.0';
+const String flexTrackVersion = '2.0.0';
 
 /// FlexTrack package description
 const String flexTrackDescription =

--- a/lib/src/core/event_processor.dart
+++ b/lib/src/core/event_processor.dart
@@ -12,8 +12,8 @@ class EventProcessor {
   final RoutingEngine _routingEngine;
   final List<EventTransformer> _transformers = [];
 
-  bool _hasGeneralConsent = true;
-  bool _hasPIIConsent = true;
+  bool _hasGeneralConsent = false;
+  bool _hasPIIConsent = false;
   bool _isEnabled = true;
 
   EventProcessor({

--- a/lib/src/models/event/base_event.dart
+++ b/lib/src/models/event/base_event.dart
@@ -1,7 +1,24 @@
+import 'dart:math';
+
 import 'package:flex_track/src/models/routing/event_category.dart';
 import 'package:flex_track/src/models/routing/tracker_group.dart';
 
 abstract class BaseEvent {
+  BaseEvent({String? eventId, DateTime? timestamp})
+      : eventId = _resolveEventId(eventId),
+        timestamp = timestamp ?? DateTime.now().toUtc();
+
+  /// Stable identifier for this event occurrence.
+  ///
+  /// Supply an existing id when reconstructing an event for retry or replay.
+  /// Otherwise FlexTrack generates an RFC 4122 version 4 UUID.
+  final String eventId;
+
+  /// Immutable time at which this event occurrence was created.
+  ///
+  /// Supply the original value when reconstructing historical events.
+  final DateTime timestamp;
+
   /// Returns the name of the event.
   String get name;
 
@@ -32,10 +49,6 @@ abstract class BaseEvent {
   /// Essential events may bypass consent requirements and sampling
   bool get isEssential => false;
 
-  /// Timestamp when the event was created
-  /// Defaults to current time, but can be overridden for historical events
-  DateTime get timestamp => DateTime.now();
-
   /// Optional user ID associated with this event
   /// Used for user-specific routing and privacy compliance
   String? get userId => null;
@@ -47,6 +60,7 @@ abstract class BaseEvent {
   /// Useful for debugging and serialization
   Map<String, dynamic> toMap() {
     return {
+      'eventId': eventId,
       'name': name,
       'properties': properties,
       'category': category?.name,
@@ -65,4 +79,27 @@ abstract class BaseEvent {
   String toString() {
     return 'Event($name${category != null ? ', category: ${category!.name}' : ''})';
   }
+}
+
+final Random _eventIdRandom = Random.secure();
+
+String _resolveEventId(String? eventId) {
+  if (eventId != null) {
+    if (eventId.isEmpty) {
+      throw ArgumentError.value(eventId, 'eventId', 'Cannot be empty');
+    }
+    return eventId;
+  }
+
+  final bytes = List<int>.generate(16, (_) => _eventIdRandom.nextInt(256));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  final hex = bytes.map((byte) => byte.toRadixString(16).padLeft(2, '0'));
+  final value = hex.join();
+
+  return '${value.substring(0, 8)}-'
+      '${value.substring(8, 12)}-'
+      '${value.substring(12, 16)}-'
+      '${value.substring(16, 20)}-'
+      '${value.substring(20)}';
 }

--- a/lib/src/models/event/enriched_event.dart
+++ b/lib/src/models/event/enriched_event.dart
@@ -25,7 +25,8 @@ class EnrichedEvent extends BaseEvent {
 
   EnrichedEvent(BaseEvent original, Map<String, Object> extraProperties)
       : _original = original,
-        _extraProperties = Map.unmodifiable(extraProperties);
+        _extraProperties = Map.unmodifiable(extraProperties),
+        super(eventId: original.eventId, timestamp: original.timestamp);
 
   /// The original unwrapped event.
   BaseEvent get original => _original;
@@ -59,9 +60,6 @@ class EnrichedEvent extends BaseEvent {
 
   @override
   bool get isEssential => _original.isEssential;
-
-  @override
-  DateTime get timestamp => _original.timestamp;
 
   @override
   String? get userId => _original.userId;

--- a/lib/src/models/routing/routing_config.dart
+++ b/lib/src/models/routing/routing_config.dart
@@ -123,8 +123,10 @@ class RoutingConfiguration {
       }
 
       // Check consent requirements
-      if (!rule.shouldApply(event,
-          hasGeneralConsent: hasGeneralConsent, hasPIIConsent: hasPIIConsent)) {
+      if (enableConsentChecking &&
+          !rule.shouldApply(event,
+              hasGeneralConsent: hasGeneralConsent,
+              hasPIIConsent: hasPIIConsent)) {
         continue;
       }
 

--- a/lib/src/routing/routing_engine.dart
+++ b/lib/src/routing/routing_engine.dart
@@ -53,9 +53,10 @@ class RoutingEngine {
         }
 
         // Check if rule should be applied based on consent
-        if (!rule.shouldApply(event,
-            hasGeneralConsent: hasGeneralConsent,
-            hasPIIConsent: hasPIIConsent)) {
+        if (_configuration.enableConsentChecking &&
+            !rule.shouldApply(event,
+                hasGeneralConsent: hasGeneralConsent,
+                hasPIIConsent: hasPIIConsent)) {
           skippedRules.add(SkippedRule(
             rule: rule,
             reason: 'Consent requirements not met',

--- a/test/core/event_processor_test.dart
+++ b/test/core/event_processor_test.dart
@@ -28,6 +28,7 @@ void main() {
         trackerRegistry: trackerRegistry,
         routingEngine: routingEngine,
       );
+      eventProcessor.setConsent(general: true, pii: true);
     });
 
     group('Enable/Disable Functionality', () {

--- a/test/core/event_processor_transformer_test.dart
+++ b/test/core/event_processor_transformer_test.dart
@@ -27,6 +27,7 @@ void main() {
         trackerRegistry: trackerRegistry,
         routingEngine: routingEngine,
       );
+      eventProcessor.setConsent(general: true, pii: true);
     });
 
     test('single transformer enriches event reaching the tracker', () async {

--- a/test/core/flex_track_client_test.dart
+++ b/test/core/flex_track_client_test.dart
@@ -39,6 +39,7 @@ void main() {
           await client.initialize();
           expect(client.isInitialized, isTrue);
 
+          client.setGeneralConsent(true);
           await client.track(_TestEvent());
           expect(mock.capturedEvents, hasLength(1));
 
@@ -53,6 +54,7 @@ void main() {
           final client = await FlexTrackClient.create([mock]);
           await client.initialize();
           await client.initialize();
+          client.setGeneralConsent(true);
           await client.track(_TestEvent());
           expect(mock.capturedEvents, hasLength(1));
           await client.dispose();
@@ -103,6 +105,7 @@ void main() {
           final mock = MockTracker();
           await FlexTrack.setup([mock]);
           expect(FlexTrack.instance.client.trackerRegistry.get(mock.id), mock);
+          FlexTrack.setGeneralConsent(true);
           await FlexTrack.track(_TestEvent());
           expect(mock.capturedEvents, hasLength(1));
           await FlexTrack.reset();
@@ -111,6 +114,46 @@ void main() {
     });
 
     group('consent and processor control', () {
+      test('new clients deny general and PII consent by default', () async {
+        final client = await FlexTrackClient.create([MockTracker()]);
+
+        expect(client.getConsentStatus(), {
+          'general': false,
+          'pii': false,
+        });
+
+        await client.dispose();
+      });
+
+      test('ordinary events remain blocked until consent is granted', () async {
+        final mock = MockTracker();
+        final client = await FlexTrackClient.create([mock]);
+
+        expect((await client.track(_TestEvent())).wasTracked, isFalse);
+        client.setGeneralConsent(true);
+        expect((await client.track(_TestEvent())).wasTracked, isTrue);
+
+        await client.dispose();
+      });
+
+      test('essential events bypass the default-deny consent state', () async {
+        final mock = MockTracker();
+        final client = await FlexTrackClient.create([mock]);
+
+        expect((await client.track(_EssentialTestEvent())).wasTracked, isTrue);
+
+        await client.dispose();
+      });
+
+      test('disabled consent checking bypasses the consent gate', () async {
+        final mock = MockTracker();
+        final client = await _clientWithRelaxedRouting([mock]);
+
+        expect((await client.track(_TestEvent())).wasTracked, isTrue);
+
+        await client.dispose();
+      });
+
       test(
         'events that require consent are not delivered when general consent is denied',
         () async {
@@ -395,6 +438,11 @@ class _NamedTestEvent extends BaseEvent {
 
   @override
   Map<String, Object>? get properties => const {};
+}
+
+class _EssentialTestEvent extends _TestEvent {
+  @override
+  bool get isEssential => true;
 }
 
 class _BrokenInitTracker extends NoOpTracker {

--- a/test/core/flex_track_client_transformer_test.dart
+++ b/test/core/flex_track_client_transformer_test.dart
@@ -8,6 +8,7 @@ Future<(FlexTrackClient, MockTracker)> _makeClient() async {
   final client = await FlexTrackClient.create(
     [mock],
     routing: RoutingConfiguration(
+      enableConsentChecking: false,
       rules: [RoutingRule(isDefault: true, targetGroup: TrackerGroup.all)],
     ),
   );

--- a/test/core/flex_track_facade_test.dart
+++ b/test/core/flex_track_facade_test.dart
@@ -77,4 +77,10 @@ class _FacadeTestEvent extends BaseEvent {
 
   @override
   Map<String, Object>? get properties => const {};
+
+  @override
+  bool get requiresConsent => false;
+
+  @override
+  bool get isEssential => true;
 }

--- a/test/core/flex_track_test.dart
+++ b/test/core/flex_track_test.dart
@@ -12,6 +12,12 @@ class TestEvent extends BaseEvent {
 
   @override
   Map<String, Object> get properties => {'test_property': testProperty};
+
+  @override
+  bool get requiresConsent => false;
+
+  @override
+  bool get isEssential => true;
 }
 
 class PurchaseTestEvent extends BaseEvent {
@@ -128,6 +134,7 @@ void main() {
 
       test('should track multiple events', () async {
         await FlexTrack.setup([mockTracker1]);
+        FlexTrack.setConsent(general: true);
 
         final events = [
           TestEvent(testProperty: 'value1'),
@@ -182,6 +189,8 @@ void main() {
           return builder; // Return the builder
         });
 
+        FlexTrack.setConsent(general: true);
+
         // Clear any existing events
         mockTracker1.clearCapturedData();
         mockTracker2.clearCapturedData();
@@ -212,6 +221,8 @@ void main() {
 
           return builder;
         });
+
+        FlexTrack.setConsent(general: true);
 
         // Clear trackers
         mockTracker1.clearCapturedData();
@@ -260,7 +271,7 @@ void main() {
         FlexTrack.setConsent(general: false, pii: false);
 
         // Regular event requiring consent should be blocked
-        await FlexTrack.track(TestEvent(testProperty: 'blocked'));
+        await FlexTrack.track(DebugTestEvent());
         expect(mockTracker1.capturedEvents, hasLength(0));
 
         // Essential event should go through regardless
@@ -440,6 +451,8 @@ void main() {
           return builder;
         });
 
+        FlexTrack.setConsent(general: true);
+
         final businessEvent = PurchaseTestEvent(amount: 100.0);
         final debugInfo = FlexTrack.debugEvent(businessEvent);
 
@@ -506,7 +519,7 @@ void main() {
 
         // Track multiple events
         for (int i = 0; i < 10; i++) {
-          await FlexTrack.track(TestEvent(testProperty: 'sample_test_$i'));
+          await FlexTrack.track(DebugTestEvent());
         }
 
         // With 0% sampling, no events should be tracked

--- a/test/models/event/base_event_test.dart
+++ b/test/models/event/base_event_test.dart
@@ -18,6 +18,44 @@ void main() {
       // ignore: deprecated_member_use_from_same_package
       expect(event.properties, event.properties);
     });
+
+    test('captures one immutable occurrence timestamp', () async {
+      final before = DateTime.now().toUtc();
+      final event = _SampleEvent();
+      final first = event.timestamp;
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+
+      expect(event.timestamp, same(first));
+      expect(first.isBefore(before), isFalse);
+    });
+
+    test('generates a unique UUID event id', () {
+      final ids = List.generate(100, (_) => _SampleEvent().eventId);
+
+      expect(ids.toSet(), hasLength(ids.length));
+      for (final id in ids) {
+        expect(
+          id,
+          matches(
+            RegExp(
+              r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+            ),
+          ),
+        );
+      }
+    });
+
+    test('accepts explicit identity and occurrence time', () {
+      final timestamp = DateTime.utc(2024, 1, 2, 3, 4, 5);
+      final event = _MetadataEvent(
+        eventId: 'event-for-replay',
+        timestamp: timestamp,
+      );
+
+      expect(event.eventId, 'event-for-replay');
+      expect(event.timestamp, same(timestamp));
+      expect(event.toMap(), containsPair('eventId', 'event-for-replay'));
+    });
   });
 }
 
@@ -27,4 +65,14 @@ class _SampleEvent extends BaseEvent {
 
   @override
   Map<String, Object>? get properties => const {'key': 'value'};
+}
+
+class _MetadataEvent extends BaseEvent {
+  _MetadataEvent({super.eventId, super.timestamp});
+
+  @override
+  String get name => 'metadata';
+
+  @override
+  Map<String, Object>? get properties => null;
 }

--- a/test/models/event/enriched_event_test.dart
+++ b/test/models/event/enriched_event_test.dart
@@ -70,11 +70,21 @@ void main() {
     });
 
     test('forwards timestamp from original', () {
-      // Capture once — BaseEvent.timestamp calls DateTime.now() each time
+      // Capture once to verify the enriched event forwards the same value.
       final fixedTime = DateTime(2024, 1, 1);
       final fixedEvent = _FixedTimestampEvent(fixedTime);
       final enriched = EnrichedEvent(fixedEvent, {});
       expect(enriched.timestamp, equals(fixedTime));
+    });
+
+    test('preserves event id and timestamp through nested enrichment', () {
+      final first = EnrichedEvent(original, {'layer': 1});
+      final second = EnrichedEvent(first, {'layer': 2});
+
+      expect(first.eventId, original.eventId);
+      expect(second.eventId, original.eventId);
+      expect(first.timestamp, same(original.timestamp));
+      expect(second.timestamp, same(original.timestamp));
     });
 
     test('forwards userId from original', () {

--- a/test/routing/presets/smart_defaults_test.dart
+++ b/test/routing/presets/smart_defaults_test.dart
@@ -432,6 +432,8 @@ void main() {
           return builder;
         });
 
+        FlexTrack.setConsent(general: true);
+
         final technicalEvent = TestEvent('debug_test', EventCategory.technical);
 
         // In debug mode, technical events should go to development trackers
@@ -602,6 +604,9 @@ class TestEvent extends BaseEvent {
 
   @override
   EventCategory? get category => eventCategory;
+
+  @override
+  bool get requiresConsent => false;
 }
 
 class HighVolumeTestEvent extends BaseEvent {
@@ -617,6 +622,9 @@ class HighVolumeTestEvent extends BaseEvent {
 
   @override
   bool get isHighVolume => true;
+
+  @override
+  bool get isEssential => true;
 }
 
 class EssentialTestEvent extends BaseEvent {

--- a/test/test_utils/mock_events.dart
+++ b/test/test_utils/mock_events.dart
@@ -15,7 +15,7 @@ class CustomEvent extends BaseEvent {
     EventCategory? category,
     bool containsPII = false,
     bool isHighVolume = false,
-    bool isEssential = false,
+    bool isEssential = true,
   })  : _properties = properties,
         _category = category,
         _containsPII = containsPII,
@@ -28,7 +28,7 @@ class CustomEvent extends BaseEvent {
     EventCategory? category,
     bool containsPII = false,
     bool isHighVolume = false,
-    bool isEssential = false,
+    bool isEssential = true,
   }) {
     return CustomEvent(
       name,
@@ -59,6 +59,10 @@ class CustomEvent extends BaseEvent {
 
   @override
   bool get isEssential => _isEssential;
+
+  // Most tests using this fixture exercise routing or dispatch, not consent.
+  @override
+  bool get requiresConsent => false;
 }
 
 class PurchaseEvent extends CustomEvent {

--- a/test/version_test.dart
+++ b/test/version_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:flex_track/flex_track.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('exported package version matches pubspec', () {
+    final pubspec = File('pubspec.yaml').readAsStringSync();
+    final match =
+        RegExp(r'^version:\s*(\S+)\s*$', multiLine: true).firstMatch(pubspec);
+
+    expect(match, isNotNull);
+    expect(flexTrackVersion, match!.group(1));
+  });
+}

--- a/test/widgets/flex_click_track_test.dart
+++ b/test/widgets/flex_click_track_test.dart
@@ -186,6 +186,7 @@ void main() {
         (tester) async {
       final mock = MockTracker();
       final client = await FlexTrackClient.create([mock]);
+      client.setGeneralConsent(true);
       addTearDown(() async {
         await client.dispose();
       });
@@ -215,6 +216,7 @@ void main() {
       final globalMock = await setupFlexTrackForTesting();
       final scopedMock = MockTracker();
       final scopedClient = await FlexTrackClient.create([scopedMock]);
+      scopedClient.setGeneralConsent(true);
       addTearDown(() async {
         await scopedClient.dispose();
       });

--- a/test/widgets/flex_impression_track_test.dart
+++ b/test/widgets/flex_impression_track_test.dart
@@ -210,6 +210,7 @@ void main() {
         (tester) async {
       final mock = MockTracker();
       final client = await FlexTrackClient.create([mock]);
+      client.setGeneralConsent(true);
       addTearDown(() async {
         await client.dispose();
       });
@@ -246,6 +247,7 @@ void main() {
       final globalMock = await setupFlexTrackForTesting();
       final scopedMock = MockTracker();
       final scopedClient = await FlexTrackClient.create([scopedMock]);
+      scopedClient.setGeneralConsent(true);
       addTearDown(() async {
         await scopedClient.dispose();
       });

--- a/test/widgets/flex_mount_track_test.dart
+++ b/test/widgets/flex_mount_track_test.dart
@@ -106,6 +106,7 @@ void main() {
         (tester) async {
       final mock = MockTracker();
       final client = await FlexTrackClient.create([mock]);
+      client.setGeneralConsent(true);
       addTearDown(() async {
         await client.dispose();
       });
@@ -133,6 +134,7 @@ void main() {
       final globalMock = await setupFlexTrackForTesting();
       final scopedMock = MockTracker();
       final scopedClient = await FlexTrackClient.create([scopedMock]);
+      scopedClient.setGeneralConsent(true);
       addTearDown(() async {
         await scopedClient.dispose();
       });

--- a/test/widgets/flex_route_track_test.dart
+++ b/test/widgets/flex_route_track_test.dart
@@ -289,6 +289,7 @@ void main() {
         (tester) async {
       final mock = MockTracker();
       final client = await FlexTrackClient.create([mock]);
+      client.setGeneralConsent(true);
       addTearDown(() async {
         await client.dispose();
       });
@@ -316,6 +317,7 @@ void main() {
       final globalMock = await setupFlexTrackForTesting();
       final scopedMock = MockTracker();
       final scopedClient = await FlexTrackClient.create([scopedMock]);
+      scopedClient.setGeneralConsent(true);
       addTearDown(() async {
         await scopedClient.dispose();
       });

--- a/test/widgets/transformer_widget_test.dart
+++ b/test/widgets/transformer_widget_test.dart
@@ -13,6 +13,7 @@ void main() {
       final client = await FlexTrackClient.create(
         [mock],
         routing: RoutingConfiguration(
+          enableConsentChecking: false,
           rules: [RoutingRule(isDefault: true, targetGroup: TrackerGroup.all)],
         ),
       );
@@ -53,6 +54,7 @@ void main() {
       final client = await FlexTrackClient.create(
         [mock],
         routing: RoutingConfiguration(
+          enableConsentChecking: false,
           rules: [RoutingRule(isDefault: true, targetGroup: TrackerGroup.all)],
         ),
       );
@@ -92,6 +94,7 @@ void main() {
       final client = await FlexTrackClient.create(
         [mock],
         routing: RoutingConfiguration(
+          enableConsentChecking: false,
           rules: [RoutingRule(isDefault: true, targetGroup: TrackerGroup.all)],
         ),
       );


### PR DESCRIPTION
- add immutable UUID event IDs and UTC timestamps
- preserve event metadata during enrichment
- default new clients to denied consent
- align package version metadata and documentation